### PR TITLE
Load events file from command line

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,10 @@
 {
-  "name": "maitreya",
-  "productName": "maitreya",
+  "name": "convomap",
+  "productName": "convomap",
   "version": "0.0.0",
   "main": "src/index.ts",
   "scripts": {
-    "main:start": "NODE_ENV=development webpack serve --config webpack.config.js --open --open-page webpack-dev-server/",
-    "main:build": "NODE_ENV=production webpack --config webpack.config.js",
-    "editor:build": "NODE_ENV=development webpack --config webpack.config.js",
-    "editor:start": "npm run editor:build && electron ./dist/editorElectron.js",
+    "dev": "NODE_ENV=development webpack --config webpack.config.js && electron ./dist/editorElectron.js",
     "lint": "prettier --check .",
     "fix": "prettier --write ."
   },

--- a/src/editor/ipc/fileReadWriteChannel.ts
+++ b/src/editor/ipc/fileReadWriteChannel.ts
@@ -8,6 +8,7 @@ const eventsFilePath = process.argv[0]
 if (!eventsFilePath) {
   throw new Error("No event file provided")
 }
+console.info(`The events file is`, path.resolve(eventsFilePath))
 
 // The types in this IPC channel should be the same as those in preload.ts -
 // they are not automatically checked by TypeScript

--- a/src/editor/ipc/fileReadWriteChannel.ts
+++ b/src/editor/ipc/fileReadWriteChannel.ts
@@ -3,70 +3,50 @@ import { IpcMainEvent } from "electron"
 import path from "path"
 import fs from "fs"
 import { execSync } from "child_process"
-import recursiveReadDir from "recursive-readdir"
 
-const eventsPath = path.resolve("./src/events/")
+const eventsFilePath = process.argv[0]
+if (!eventsFilePath) {
+  throw new Error("No event file provided")
+}
 
 // The types in this IPC channel should be the same as those in preload.ts -
 // they are not automatically checked by TypeScript
 
 /**
- * Reads the events dir and returns a list of files within it.
+ * Reads the events file that was specified on the command line and sends
+ * its contents back to the renderer process.
  */
-export class ReadEventsDirChannel implements IpcChannelInterface {
-  name = "read-events-dir"
+export class ReadEventsFileChannel implements IpcChannelInterface {
+  name = "read-events-file"
 
   handle(event: IpcMainEvent, request: IpcRequest<never>): void {
-    recursiveReadDir(eventsPath, (_, filePaths) => {
-      filePaths = filePaths.map((filePath) =>
-        // Strip the constant part of the path from the list to make a list
-        // of paths relative to the events directory
-        filePath.slice(eventsPath.length)
-      )
-      if (!request.responseChannel) {
-        request.responseChannel = `${this.name}_response`
-      }
-      event.sender.send(request.responseChannel, filePaths)
-    })
+    const eventsFile = fs.readFileSync(path.resolve(eventsFilePath), "utf-8")
+
+    if (!request.responseChannel) {
+      request.responseChannel = `${this.name}_response`
+    }
+    event.sender.send(request.responseChannel, eventsFile)
   }
 }
 
 /**
- * Reads an individual events file and returns its contents.
+ * Writes a string to the events file, replacing its existing contents, and
+ * backing up the previous contents to another file.
+ *
+ * Called with a single argument which is a string representing the
+ * contents of the new file.
  */
-export class ReadEventsFileChannel implements IpcChannelInterface {
-  name = "read-events-file"
+export class WriteEventsFileChannel implements IpcChannelInterface {
+  name = "write-events-file"
 
   handle(event: IpcMainEvent, request: IpcRequest<string>): void {
     if (!request.responseChannel) {
       request.responseChannel = `${this.name}_response`
     }
-    const filePath = request.params
-    const file = path.join(eventsPath, filePath)
-    const eventFile = fs.readFileSync(file, "utf-8")
-    event.sender.send(request.responseChannel, eventFile)
-  }
-}
-
-/**
- * Writes a string to an events file, replacing its existing contents, and
- * backing up the previous contents to another file.
- *
- * Parameters for the IpcRequest:
- * @param 0 - Path from the root events dir to the wanted events file.
- * @param 1 - Textual content of the new file.
- */
-export class WriteEventsFileChannel implements IpcChannelInterface {
-  name = "write-events-file"
-
-  handle(event: IpcMainEvent, request: IpcRequest<[string, string]>): void {
-    if (!request.responseChannel) {
-      request.responseChannel = `${this.name}_response`
-    }
-    const [filePath, textContent] = request.params
-    const file = path.join(eventsPath, filePath)
+    const textContent = request.params
     // Create a specific backup. The file name is hashed against the
     // current date, time, and most recent commit.
+    // TODO Handle case when this fails / git not in use
     const commitHash = execSync("git rev-parse HEAD", {
       encoding: "utf-8",
     }).substring(0, 8)
@@ -76,17 +56,18 @@ export class WriteEventsFileChannel implements IpcChannelInterface {
     const currentTime = new Date(
       Math.floor(new Date().getTime() / halfAnHour) * halfAnHour
     )
-    const backupFile = path.join(
-      eventsPath,
-      filePath.replace(
-        ".json",
-        `.${currentTime.toISOString()}-${commitHash}.bak.json`
-      )
+    const backupFilePath = eventsFilePath.replace(
+      ".json",
+      `.bak.${currentTime.toISOString()}-${commitHash}.json`
     )
     // Back up the events file, failing if a file with the same name exists
-    fs.copyFileSync(file, backupFile, fs.constants.COPYFILE_EXCL)
+    fs.copyFileSync(
+      path.resolve(eventsFilePath),
+      path.resolve(backupFilePath),
+      fs.constants.COPYFILE_EXCL
+    )
     // Write the new file
-    fs.writeFileSync(file, textContent)
+    fs.writeFileSync(path.resolve(eventsFilePath), textContent)
     // Inform the renderer process that the file has been saved
     event.sender.send(request.responseChannel)
   }

--- a/src/editor/lib/eventsFilesystemProxy.ts
+++ b/src/editor/lib/eventsFilesystemProxy.ts
@@ -1,65 +1,45 @@
-import { Event, EventsList } from "../types"
+import { Event, EventsRegistry } from "../types"
 
 /**
- * Asynchronously creates a proxy for the events directory.
+ * Asynchronously creates a proxy for the events file.
  *
  * The proxy here constructs a fake interactions tree and populates it with
  * the files it contains, and intercepts save requests and transmits them to the
- * file proxies.
+ * file.
  *
- * @param events - The events list to store the events in.
+ * @param events - The events object to store the events in.
+ *
+ * @returns A Proxy that wraps the provided events object; old references
+ * to the events object should point to the Proxy if they want edit events
+ * to be transmitted.
  */
-export function createEventsDirProxy(events: EventsList): EventsList {
+export function createEventsFileProxy(
+  eventsRegistry: EventsRegistry
+): EventsRegistry {
   console.log("Creating events dir proxy")
-  window.fileReadWrite.readEventsDir.singleResponse((filePaths) => {
+  window.fileReadWrite.readEventsFile.singleResponse((eventsFile) => {
     // Construct and bind this event's children
-    filePaths.forEach((filePath) => {
-      createEventFileProxy(filePath, events)
-    })
+    console.log("Received events file read")
+    // Parse the events file to what is hopefully a valid events registry
+    // structure - TODO verify this
+    const eventsRegistryOnFile = <EventsRegistry>JSON.parse(eventsFile)
+    // TODO Input validation
+    eventsRegistry._meta = eventsRegistryOnFile._meta
+    eventsRegistry.events = eventsRegistryOnFile.events
+    // Assigning each property individually so as not to overwrite the
+    // object reference - might be a better way of doing this
   })
-  window.fileReadWrite.readEventsDir.send()
-  return new Proxy(events, {
+  window.fileReadWrite.readEventsFile.send()
+  return new Proxy(eventsRegistry, {
     set(events, eventId: string, event: Event) {
       console.log("Applying update to event", JSON.stringify(eventId))
       window.fileReadWrite.writeEventsFile.singleResponse(() => {
         console.log("Backup successful for", JSON.stringify(eventId))
       })
       // Make a backup of the old file
-      window.fileReadWrite.writeEventsFile.send(
-        eventId,
-        JSON.stringify(event, null, 2)
-      )
+      window.fileReadWrite.writeEventsFile.send(JSON.stringify(event, null, 2))
       // Make the actual changes to the object
       return Reflect.set(events, eventId, event)
     },
   })
-}
-
-/**
- * Asynchronously creates a proxy for a given events file.
- *
- * The proxy here intercepts save requests and transmits them to the file.
- *
- * @param filePath - The path to the events file, including the file name,
- * relative to the events directory.
- * @param events - The list of events to append this event to.
- */
-function createEventFileProxy(filePath: string, events: EventsList): void {
-  console.log("Creating events file proxy for", JSON.stringify(filePath))
-  window.fileReadWrite.readEventsFile.singleResponse(filePath, (eventFile) => {
-    events[filePath] = new Proxy(<Event>JSON.parse(eventFile), {
-      set() {
-        console.error("this seemingly never gets called (1)")
-        return true
-      },
-      defineProperty() {
-        console.error("this seemingly never gets called (2)")
-        return true
-      },
-    })
-    // TODO Intercept save requests
-    // The handlers don't seem to ever get called. Maybe no proxy is needed?
-  })
-  console.log("Requesting file read for path", JSON.stringify(filePath))
-  window.fileReadWrite.readEventsFile.send(filePath)
 }

--- a/src/editor/preload.ts
+++ b/src/editor/preload.ts
@@ -15,8 +15,8 @@ export const fileReadWriteApi = {
      * Subscribes to the next events file read response.
      */
     singleResponse: (callback: (eventFile: string) => void): void => {
-      ipcRenderer.once("read-events-file_response", (ipcEvent, eventFile) => {
-        callback(eventFile)
+      ipcRenderer.once("read-events-file_response", (ipcEvent, eventsFile) => {
+        callback(eventsFile)
       })
     },
   },

--- a/src/editor/preload.ts
+++ b/src/editor/preload.ts
@@ -4,61 +4,31 @@ import { contextBridge, ipcRenderer } from "electron"
 // ipc/fileReadWriteChannel.ts - they are not automatically checked by
 // TypeScript
 export const fileReadWriteApi = {
-  readEventsDir: {
-    /**
-     * Reads the list of files in the events directory.
-     */
-    send: (): void => {
-      ipcRenderer.send("read-events-dir", {})
-    },
-    /**
-     * Subscribes to the next events directory read response.
-     */
-    singleResponse: (callback: (filePaths: string[]) => void): void => {
-      ipcRenderer.once("read-events-dir_response", (ipcEvent, filePaths) => {
-        callback(filePaths)
-      })
-    },
-  },
   readEventsFile: {
     /**
-     * Reads an individual events file.
-     *
-     * @param filePath - The path to the file, including the filename,
-     * relative to the events directory.
+     * Reads the events file.
      */
-    send: (filePath: string): void => {
-      ipcRenderer.send("read-events-file", {
-        params: filePath,
-        responseChannel: `read-events-file-${filePath}`,
-      })
+    send: (): void => {
+      ipcRenderer.send("read-events-file", {})
     },
     /**
      * Subscribes to the next events file read response.
      */
-    singleResponse: (
-      filePath: string,
-      callback: (eventFile: string) => void
-    ): void => {
-      ipcRenderer.once(
-        `read-events-file-${filePath}`,
-        (ipcEvent, eventFile) => {
-          callback(eventFile)
-        }
-      )
+    singleResponse: (callback: (eventFile: string) => void): void => {
+      ipcRenderer.once("read-events-file_response", (ipcEvent, eventFile) => {
+        callback(eventFile)
+      })
     },
   },
   writeEventsFile: {
     /**
      * Writes to an individual events file, backing up the old one.
      *
-     * @param filePath - The path to the file, including the filename,
-     * relative to the events directory.
      * @param textContent - The contents of the new events file.
      */
-    send: (filePath: string, textContent: string): void => {
+    send: (textContent: string): void => {
       ipcRenderer.send("write-events-file", {
-        params: [filePath, textContent],
+        params: textContent,
         // No custom response channel is used because I don't expect to be
         // saving multiple events that frequently when autosaving - would
         // be worth implementing if there is a save button that saves

--- a/src/editor/types.ts
+++ b/src/editor/types.ts
@@ -39,7 +39,7 @@ export type ValueId = Identifier
 /**
  * A batch of messages, used to reduce duplication of settings that would
  * have been applied to each of them individually.
- * 
+ *
  * TODO Rename property 'messages' to 'text' or similar? Property messages
  * -> messages is duplicated in output
  */
@@ -276,7 +276,7 @@ export type Interaction = {
  * An event that contains a series of interactions.
  *
  * The interactions can be arbitrarily nested into sub-events.
- * 
+ *
  * @property id - An ID for this event, which must be unique across all
  * events in the story.
  * @property summary - A short summary of the event to remind the writer
@@ -297,8 +297,15 @@ export type Event = {
 }
 
 /**
- * A list of events, keyed to the path of each event in the filesystem.
+ * The main events object, which is the contents of the events file.
+ *
+ * @property _meta - Meta information about the events. The _convomap
+ * property is required.
+ * @property events - The list of events
  */
-export type EventsList = {
-  [path: string]: Event
+export type EventsRegistry = {
+  _meta: {
+    _convomap: string
+  } & Record<string, unknown> // TODO
+  events: Event[]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,6 @@ const webpack = require("webpack")
 const { merge } = require("webpack-merge")
 const HtmlWebpackPlugin = require("html-webpack-plugin")
 const { VueLoaderPlugin } = require("vue-loader")
-const TerserPlugin = require("terser-webpack-plugin")
 
 const dev = process.env.NODE_ENV === "development"
 
@@ -52,30 +51,6 @@ const common = {
   ],
 }
 
-const mainWeb = merge(common, {
-  entry: {
-    mainWeb: "./src/index.ts",
-  },
-  optimization: {
-    minimize: !dev,
-    minimizer: [new TerserPlugin({ extractComments: false })],
-    usedExports: true,
-    splitChunks: {
-      chunks: "all",
-    },
-  },
-  plugins: [
-    new HtmlWebpackPlugin({
-      title: "Maitreya.aic",
-      filename: "index.html",
-      chunks: ["main"],
-      meta: {
-        viewport: "width=device-width, initial-scale=1",
-      },
-    }),
-  ],
-})
-
 const editorElectronMain = merge(common, {
   entry: {
     editorElectronMain: "./src/editor/electron.ts",
@@ -110,7 +85,6 @@ const editorElectronRenderer = merge(common, {
 })
 
 module.exports = [
-  // mainWeb,
   editorElectronMain,
   editorElectronPreload,
   editorElectronRenderer,


### PR DESCRIPTION
Convomap is supposed to be able to run standalone, so it necessarily needs the event file to be edited to be specified externally. Simplest way to do that is to specify it on the command line. Later I can add a boot-screen UI to pick a file, provided that one hasn't already been given, but that's way out of scope for now.

Also it's worth noting that at this point in development (#1), Convomap will only accept a single events file. So the command line argument should just point directly to it.

- [x] Take an argument from the command line that points to the events file
- [x] Make the argument required (for now)
- [x] Direct read and write requests to this file (and its backups)