### PR TITLE
Swith from Dagre to ELK for graph layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
       "babel-preset-typescript-vue3"
     ],
     "plugins": [
-      "@babel/plugin-proposal-class-properties"
+      "@babel/plugin-proposal-class-properties",
+      "@babel/plugin-transform-runtime"
     ]
   },
   "config": {
@@ -51,11 +52,13 @@
     }
   },
   "dependencies": {
+    "@babel/runtime": "^7.14.6",
     "electron-squirrel-startup": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.13.15",
     "@babel/plugin-proposal-class-properties": "^7.13.0",
+    "@babel/plugin-transform-runtime": "^7.14.5",
     "@babel/preset-env": "^7.13.15",
     "@babel/preset-typescript": "^7.13.0",
     "@electron-forge/cli": "^6.0.0-beta.54",
@@ -67,7 +70,6 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.32",
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "@fortawesome/vue-fontawesome": "^3.0.0-3",
-    "@types/dagre": "^0.7.44",
     "@types/recursive-readdir": "^2.2.0",
     "@typescript-eslint/eslint-plugin": "^4.21.0",
     "@typescript-eslint/parser": "^4.21.0",
@@ -76,9 +78,9 @@
     "babel-loader": "^8.2.2",
     "babel-preset-typescript-vue3": "^2.0.11",
     "css-loader": "^5.2.1",
-    "dagre": "^0.8.5",
     "electron": "^12.0.7",
     "electron-devtools-installer": "^3.2.0",
+    "elkjs": "^0.7.1",
     "eslint": "^7.24.0",
     "eslint-config-prettier": "^8.2.0",
     "eslint-plugin-vue": "^7.8.0",

--- a/src/components/EditEvent.vue
+++ b/src/components/EditEvent.vue
@@ -156,25 +156,26 @@ export default defineComponent({
   --canvas-line: hsl(200, 50%, 90%);
   --canvas-line-width: 1px;
   border: calc(var(--canvas-line-width) * 2) solid var(--canvas-line);
+  background-image: linear-gradient(
+      to bottom,
+      var(--canvas-line) var(--canvas-line-width),
+      transparent 0
+    ),
+    linear-gradient(
+      to right,
+      var(--canvas-line) var(--canvas-line-width),
+      var(--canvas-bg) 0
+    );
+  background-size: 1rem 1rem;
+  background-attachment: local;
   overflow: scroll;
   // Limit the canvas to be the width of the window minus its parent's
   // horizontal margins - height is already limited by flex
   max-width: calc(100vw - 0);
+  min-width: calc(100%);
 
   .tree {
     position: relative;
-    background-image: linear-gradient(
-        to bottom,
-        var(--canvas-line) var(--canvas-line-width),
-        transparent 0
-      ),
-      linear-gradient(
-        to right,
-        var(--canvas-line) var(--canvas-line-width),
-        var(--canvas-bg) 0
-      );
-    background-size: 1rem 1rem;
-    background-attachment: local;
 
     svg {
       position: absolute;

--- a/src/components/EditEvent.vue
+++ b/src/components/EditEvent.vue
@@ -10,7 +10,7 @@
       label="Summary"
       @update-value="(value) => update((e) => (e.summary = value))"
     ></FieldText>
-    <div class="canvas">
+    <div v-if="interactionsLayout" class="canvas">
       <div
         class="tree"
         :style="{
@@ -66,7 +66,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from "vue"
+import { defineComponent, PropType, ref, watchEffect } from "vue"
 import { Event, Interaction, Option } from "../types"
 import EditInteraction from "./EditInteraction.vue"
 import EditOption from "./EditOption.vue"
@@ -94,12 +94,14 @@ export default defineComponent({
     },
   },
   emits: ["updateValue"],
-  computed: {
-    interactionsLayout(): GraphLayout {
-      const layout = createInteractionGraph(this.event.interactions)
-      console.log(layout)
-      return layout
-    },
+  setup(props) {
+    let interactionsLayout = ref<GraphLayout | null>(null)
+    watchEffect(() => {
+      void createInteractionGraph(props.event.interactions).then(
+        (graphLayout) => (interactionsLayout.value = graphLayout)
+      )
+    })
+    return { interactionsLayout }
   },
   methods: {
     /**
@@ -130,7 +132,7 @@ export default defineComponent({
       const searchId = option
         ? getOptionId(interaction, option)
         : interaction.id
-      const node = this.interactionsLayout.nodes.find(
+      const node = this.interactionsLayout?.nodes.find(
         (node) => node.id === searchId
       )
       // TODO Height and width should not be needed

--- a/src/lib/graphLayout.ts
+++ b/src/lib/graphLayout.ts
@@ -49,6 +49,7 @@ export async function createInteractionGraph(
       }
     })
   })
+  console.log(elk.knownLayoutOptions())
 
   // Generate the graph
   const graph = await elk.layout({
@@ -56,7 +57,15 @@ export async function createInteractionGraph(
     layoutOptions: {
       "elk.algorithm": "layered",
       "elk.direction": "DOWN",
+      // Network simplex strategy looks cleaner for dialogue tree
       "elk.layered.nodePlacement.strategy": "NETWORK_SIMPLEX",
+      // Combine arrows between nodes to single multi-arrow
+      "elk.layered.mergeEdges": "true",
+      // Increase spacing between node layers
+      "elk.layered.spacing.nodeNodeBetweenLayers": "30", // Below arrow
+      "elk.layered.spacing.edgeNodeBetweenLayers": "30", // Above arrow
+      // Increase spacing between nodes in same layer
+      "elk.spacing.nodeNode": "40",
     },
     children: elkChildren,
     edges: elkEdges.map((edge, index) => {
@@ -72,12 +81,8 @@ export async function createInteractionGraph(
 
   // Extract nodes
   const nodes = graph.children!.map((node) => {
-    // The coords of each node are at their centre, but for CSS positioning
-    // I want the coords of the top-right corner
     return {
       id: node.id,
-      // x: node.x! - node.width! / 2,
-      // y: node.y! - node.height! / 2,
       x: node.x!,
       y: node.y!,
       height: node.height!,

--- a/src/lib/graphLayout.ts
+++ b/src/lib/graphLayout.ts
@@ -1,4 +1,6 @@
-import dagre from "dagre"
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+import ELK, { ElkExtendedEdge, ElkNode } from "elkjs/lib/elk.bundled"
 import { Interaction } from "types"
 import { getOptionId } from "./identifier"
 
@@ -13,68 +15,85 @@ export type GraphLayout = Dimensions & { edges: Edge[]; nodes: Node[] }
  *
  * @param interactions - The list of interactions to render.
  */
-export function createInteractionGraph(
+export async function createInteractionGraph(
   interactions: Interaction[]
-): GraphLayout {
-  const graph = new dagre.graphlib.Graph()
-  graph.setGraph({})
+): Promise<GraphLayout> {
+  const elk = new ELK()
 
-  // No labels on this graph
-  graph.setDefaultEdgeLabel(() => ({}))
-  graph.setDefaultNodeLabel(() => ({}))
+  const elkChildren: ElkNode[] = []
+  const elkEdges: { source: string; target: string }[] = []
 
   // Iterate through interactions to render them
   interactions.forEach((interaction) => {
     // Just use a default width and height for now
     // TODO Get width and height from HTML
-    graph.setNode(interaction.id, { width: 300, height: 300 })
+    elkChildren.push({ id: interaction.id, width: 300, height: 300 })
     if (interaction.fallbackTargetInteraction) {
       // Connect this interaction and its fallback, if any
-      graph.setEdge(interaction.id, interaction.fallbackTargetInteraction)
+      elkEdges.push({
+        source: interaction.id,
+        target: interaction.fallbackTargetInteraction,
+      })
     }
     // Also iterate the options
     interaction.options?.forEach((option) => {
       const optionId = getOptionId(interaction, option)
-      graph.setNode(optionId, {
-        width: 300,
-        height: 100,
-      })
+      elkChildren.push({ id: optionId, width: 300, height: 100 })
       // Connect this option and its parent interaction
-      graph.setEdge(interaction.id, optionId)
+      elkEdges.push({ source: interaction.id, target: optionId })
       // Connect this option and its target interaction
       // The target interaction can be Conditional, which must be resolved
       // TODO Resolve conditional target interaction
       if (typeof option.targetInteraction === "string") {
-        graph.setEdge(optionId, option.targetInteraction)
+        elkEdges.push({ source: optionId, target: option.targetInteraction })
       }
     })
   })
 
   // Generate the graph
-  dagre.layout(graph)
+  const graph = await elk.layout({
+    id: "root",
+    layoutOptions: {
+      "elk.algorithm": "layered",
+      "elk.direction": "DOWN",
+      "elk.layered.nodePlacement.strategy": "NETWORK_SIMPLEX",
+    },
+    children: elkChildren,
+    edges: elkEdges.map((edge, index) => {
+      return {
+        id: `e${index}`,
+        sources: [edge.source],
+        targets: [edge.target],
+      }
+    }),
+  })
+
+  console.log(graph)
 
   // Extract nodes
-  const nodes = graph.nodes().map((nodeId) => {
-    const node = graph.node(nodeId)
+  const nodes = graph.children!.map((node) => {
     // The coords of each node are at their centre, but for CSS positioning
     // I want the coords of the top-right corner
-    node.x = node.x - node.width / 2
-    node.y = node.y - node.height / 2
-    return { ...node, id: nodeId }
+    return {
+      id: node.id,
+      // x: node.x! - node.width! / 2,
+      // y: node.y! - node.height! / 2,
+      x: node.x!,
+      y: node.y!,
+      height: node.height!,
+      width: node.width!,
+    }
   })
 
   // Extract edges
-  const edges = graph.edges().map((edgeId) => {
-    const edge = graph.edge(edgeId)
-    return edge.points
+  const edges = (<ElkExtendedEdge[]>graph.edges).map((edge) => {
+    const section = edge.sections[0]
+    return [section.startPoint, ...(section.bendPoints ?? []), section.endPoint]
   })
 
   // Extract the graph itself
-  // The graph has been calculated, so assert that it has the properties we
-  // want
-  const graphInfo = <Dimensions>graph.graph()
-  const height = graphInfo.height
-  const width = graphInfo.width
+  const height = graph.height!
+  const width = graph.width!
 
   return {
     height,


### PR DESCRIPTION
[Dagre](https://github.com/dagrejs/dagre) is nice but its graph leaves a little to be desired - the edge placement makes little sense for my purposes, and there's no way to customise it:

![image](https://user-images.githubusercontent.com/29130152/123548797-3326a380-d75e-11eb-9c85-685f715023bc.png)

Having considered a lot of alternatives, I've settled on [elkjs](https://github.com/kieler/elkjs), a port of the Eclipse Layout Kernel. I'm working mostly in Electron here so I don't give a damn about bundle size.

Their [layered algorithm] particularly appealed to me, but its default settings result in weird node placement:

![image](https://user-images.githubusercontent.com/29130152/123548863-7bde5c80-d75e-11eb-96db-0d62b3bcb91e.png)

But I resolved that by changing the [node placement strategy](http://www.eclipse.org/elk/reference/options/org-eclipse-elk-layered-nodePlacement-strategy.html) from the default BRANDES_KOEPF to NETWORK_SIMPLEX, which might even look quite nice with a bit of extra spacing:

![image](https://user-images.githubusercontent.com/29130152/123548921-c8299c80-d75e-11eb-8688-c6b93d82590b.png)

I believe ELK provides ways to adjust where the edges bind to the nodes - I think they're called 'ports' - which may allow me to easily merge the edges together.

elkjs is licensed under the Eclipse Public License 1.0. I need to check to see if it's compatible with my MIT licence, but as I'm only using it as a dependency and not redistributing it, I'm pretty sure it is.... although it *is* getting bundled?