### PR TITLE
Calculate node size from content

### DIFF
--- a/src/components/EditEvent.vue
+++ b/src/components/EditEvent.vue
@@ -130,8 +130,6 @@ export default defineComponent({
       interaction: Interaction,
       option?: Option
     ): {
-      height: string
-      width: string
       top: string
       left: string
     } {
@@ -141,15 +139,9 @@ export default defineComponent({
       const node = this.interactionsLayout?.nodes.find(
         (node) => node.id === searchId
       )
-      // TODO Height and width should not be needed
       const style = node
-        ? {
-            height: `${node.height}px`,
-            width: `${node.width}px`,
-            left: `${node.x}px`,
-            top: `${node.y}px`,
-          }
-        : { height: "0px", width: "0px", left: "0px", top: "0px" }
+        ? { left: `${node.x}px`, top: `${node.y}px` }
+        : { left: "0px", top: "0px" }
       return style
     },
   },

--- a/src/components/EditEvent.vue
+++ b/src/components/EditEvent.vue
@@ -54,6 +54,7 @@
             :interaction="interaction"
             class="interaction"
             :style="getInteractionLayoutStyle(interaction)"
+            :data-node-id="interaction.id"
             @update-value="
               (i) => update((e) => (e.interactions[interactionIndex] = i))
             "
@@ -64,6 +65,7 @@
             :key="optionIndex"
             class="option"
             :style="getInteractionLayoutStyle(interaction, option)"
+            :data-node-id="getOptionId(interaction, option)"
           ></EditOption>
         </div>
       </div>

--- a/src/components/EditEvent.vue
+++ b/src/components/EditEvent.vue
@@ -10,16 +10,20 @@
       label="Summary"
       @update-value="(value) => update((e) => (e.summary = value))"
     ></FieldText>
-    <div v-if="interactionsLayout" class="canvas">
+    <div class="canvas">
       <div
         class="tree"
-        :style="{
-          height: `${interactionsLayout.height}px`,
-          width: `${interactionsLayout.width}px`,
-        }"
+        :style="
+          interactionsLayout
+            ? {
+                height: `${interactionsLayout.height}px`,
+                width: `${interactionsLayout.width}px`,
+              }
+            : { opacity: '0' }
+        "
       >
         <!-- Arrows between nodes -->
-        <svg xmlns="http://www.w3.org/2000/svg">
+        <svg v-if="interactionsLayout" xmlns="http://www.w3.org/2000/svg">
           <defs>
             <marker
               id="arrowhead"
@@ -178,6 +182,7 @@ export default defineComponent({
 
   .tree {
     position: relative;
+    transition: opacity 0.3s ease;
 
     svg {
       position: absolute;


### PR DESCRIPTION
The current graph layout algorithm (#3) is naive in that it assumes interactions and options are all static size (300x300px and 100x300px respectively). However, node size can vary based on what they contain (eventually, presumably), so the sizes should be read from the DOM.

The components in question are EditInteraction and EditOption. I'll make some way to share the functionality between them, possibly a mixin or something imported into setup - the specifics don't matter. What does matter is how I get the information back to the layout engine.

The layout engine does what it needs to and then shits the result out onto the canvas and then forgets about it. In the future it'll be re-called each time the graph changes, but I'm not at that stage yet (although I did already add a `watchEffect` which might do it already - not tested). Critically, there's no binding of the edit components back to the data - they just have specific update events configured that echo any changes upwards.

I think possibly a good solution would be to pass the ID (or pseudo-ID in the case of options) of the node as a prop to the component - or if not a prop, at least an attribute. Then I should be able to read the components in order and know exactly which data point they refer to. (EDIT: I can just use the iteration key for this, right?)

A difficulty I might have there is getting that information back to the layout engine. It currently handles all forms of layout, both sizing and positioning. I would need to defer sizing to Vue and the browser, let it calculate that, and then take that information and give it to ELK to calculate the positioning. Splitting up the layouting like that is not going to be intuitive. There might be a good reason that Twine assumes all of its nodes are square.