### PR TITLE
Draw graph edges as splines

### DIFF
--- a/src/components/ArrowConnector.vue
+++ b/src/components/ArrowConnector.vue
@@ -4,7 +4,7 @@
 
 <script lang="ts">
 import { defineComponent, PropType } from "vue"
-import { Edge, pointToCoords } from "../lib/graphLayout"
+import { Edge } from "../lib/graphLayout"
 
 export default defineComponent({
   name: "ArrowConnector",
@@ -16,11 +16,21 @@ export default defineComponent({
   },
   computed: {
     arrowPath(): string {
-      return [
-        "M",
-        pointToCoords(this.points[0]),
-        ...this.points.slice(1).flatMap((point) => ["L", pointToCoords(point)]),
-      ].join(" ")
+      if (this.points.length === 2) {
+        return `
+          M ${this.points[0].x} ${this.points[0].y}
+          L ${this.points[1].x} ${this.points[1].y}
+        `
+      }
+      if (this.points.length === 4) {
+        return `
+          M ${this.points[0].x} ${this.points[0].y}
+          C ${this.points[1].x} ${this.points[1].y}
+          , ${this.points[2].x} ${this.points[2].y}
+          , ${this.points[3].x} ${this.points[3].y}
+        `
+      }
+      throw new Error("ELK spline does not contain either 2 or 4 points")
     },
   },
 })

--- a/src/lib/graphLayout.ts
+++ b/src/lib/graphLayout.ts
@@ -66,6 +66,7 @@ export async function createInteractionGraph(
       "elk.layered.spacing.edgeNodeBetweenLayers": "30", // Above arrow
       // Increase spacing between nodes in same layer
       "elk.spacing.nodeNode": "40",
+      "elk.edgeRouting": "SPLINE",
     },
     children: elkChildren,
     edges: elkEdges.map((edge, index) => {
@@ -106,13 +107,4 @@ export async function createInteractionGraph(
     edges,
     nodes,
   }
-}
-
-/**
- * Represents a point as numeric coords joined with a comma.
- *
- * @param point - The point to transform.
- */
-export function pointToCoords(point: Point): string {
-  return `${point.x}, ${point.y}`
 }


### PR DESCRIPTION
The ELK Layered algorithm (#4) supports being able to show edges drawn as a smooth spline:

Orthogonal | Spline
--- | ---
![image](https://user-images.githubusercontent.com/29130152/123664057-e959be00-d82e-11eb-9175-7c875a547e1f.png) | ![image](https://user-images.githubusercontent.com/29130152/123685760-f08cc600-d846-11eb-998c-aaa845bdddff.png)

Ignoring the overlap on the top node (which is a result of the zoom level - it's not like that at 100% zoom), I'm told by an impartial observer that this looks much nicer. It would make a good default for now.

Later, I could have user-level settings (NOT saved to the events file) to control trivial display features like this. But not yet.

One thing to bear in mind is that the spline renderer assumes that ELK will output either 2 points per edge, representing a straight line, or 4, representing a spline. It will throw an error in all other cases, which may prove to be a little too naive.
